### PR TITLE
Update 5-busca_binaria.c

### DIFF
--- a/src/exercicios/6_DepuracaoTestes/5-busca_binaria.c
+++ b/src/exercicios/6_DepuracaoTestes/5-busca_binaria.c
@@ -124,7 +124,7 @@ void testa_encontra_aleatorio_em_vetor_de_tamanho_10() {
 
     int i = bb(vetor, 10, (rand()%10)+1);
 
-    assert(i >= 0 <= i && i < 10);
+    assert(i >= 0 && i < 10);
 }
 
 void testa_encontra_todos_em_vetor_de_tamanho_50() {


### PR DESCRIPTION
Em testa_encontra_aleatorio_em_vetor_de_tamanho_10() o teste i >= 0 <= i,  é executado como (i >= 0) <= i, então caso i fosse 0 (primeiro elemento do vetor):
(i >= 0) <= i
(0 >= 0) <= 0
1 <= 0
0
e mesmo correto, o teste falhava.
